### PR TITLE
Grant access to Gamescope socket for Steam Deck OLED

### DIFF
--- a/io.github.Faugus.faugus-launcher.yml
+++ b/io.github.Faugus.faugus-launcher.yml
@@ -26,6 +26,7 @@ finish-args:
   - --filesystem=/mnt
   - --filesystem=/run/media
   - --filesystem=xdg-config/MangoHud:ro
+  - --filesystem=xdg-run/gamescope-0:rw
 
 inherit-extensions:
   - org.freedesktop.Platform.GL32


### PR DESCRIPTION
* See https://github.com/flathub/org.DolphinEmu.dolphin-emu/pull/178#issuecomment-1905194043 for more information
* Fairly sure bug only occurs on the Steam Deck OLED.

To replicate the error, on a Steam Deck OLED, install the Gamescope Flatpak (`org.freedesktop.Platform.VulkanLayer.gamescope`), launch Faugus Launcher in Game Mode, see error. Gamescope Flatpak is primarily used for HDR in other Flatpaks (Dolphin, PrimeHack, Heroic, etc.).

Related error:

![image](https://github.com/user-attachments/assets/745b9487-b8ed-4d3f-bb55-6e02c152ba92)